### PR TITLE
feat: implement camera guideline overlay

### DIFF
--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,32 @@
+# Perencanaan Fitur: Guideline Kamera (Onion Skinning) dari GitHub
+
+## Deskripsi Tugas
+Tugas ini bertujuan untuk menambahkan fitur panduan bayangan (guideline/onion skinning) secara live saat pengguna membuka kamera.
+Panduan yang ditampilkan menggunakan berkas gambar terakhir yang selalu ku-pull dari GitHub (berasal dari tautan mentah Github).
+Karena linknya statis tapi gambar selalu diperbarui (*update* rutin di server), kita harus memastikan sisi aplikasi selalu mengunduh versi yang terbaru dan menghindari mekanisme *cache* bawaan.
+
+**URL Sumber Gambar:**
+[https://raw.githubusercontent.com/KAnggara75/everyday/main/timelapse/last.jpg](https://raw.githubusercontent.com/KAnggara75/everyday/main/timelapse/last.jpg)
+
+## Ruang Lingkup Pengerjaan (To-Do List)
+
+- [ ] **1. Fetch Image tanpa Cache**
+  - Minta gambar `last.jpg` dari URL raw GitHub di atas.
+  - Tambahkan parameter unik seperti timestamp (Contoh: `?v=<timestamp>`) di ujung string URL agar framework tidak menggunakan berkas *cache* yang lama.
+
+- [ ] **2. Tampilkan sebagai Overlay di Kamera**
+  - Buka file `lib/camera_screen.dart` dan posisikan di dalam `Stack` yang merender widget `CameraPreview`.
+  - Letakkan fungsi `Image.network()` tersebut persis di DEPAN layer `CameraPreview()`.
+  - Pastikan dimensi bayangan (*image overlay*) menggunakan `AspectRatio(aspectRatio: 3 / 2)` dan `BoxFit.cover` agar ukurannya nge-pas sempurna (sinkron 1:1) dengan area pratinjau yang akan dijepret.
+
+- [ ] **3. Atur Transparansi (Opacity)**
+  - Bungkus `Image.network` dengan `Opacity`.
+  - Set level opasitas sekitar `0.4` hingga `0.5`. Hasil akhirnya pengguna akan melihat muka/postur mereka langsung dan dibayangi transparan oleh wujud gambar hari kemarin.
+  - Bungkus juga dengan properti pengananganan *error* `errorBuilder` (misalnya kembali mengembalikan `SizedBox.shrink()` jika file di repositori sewaktu-waktu tak bisa dijangkau).
+
+- [ ] **4. Uji Coba UI (Testing)**
+  - Pastikan pratinjau (*preview*) kamera tidak terhalang atau tak dapat dipencet alias error overlay.
+  - (*Opsional/Bonus*) Pertimbangkan menambahkan tombol toggle transparan (ikon mata) agar panduan bisa dimatikan atau dinyalakan sesuai kebutuhan!
+
+## Berkas yang Diubah
+* `lib/camera_screen.dart` -> Menambahkan widget overlay & network image.

--- a/lib/camera_screen.dart
+++ b/lib/camera_screen.dart
@@ -20,6 +20,7 @@ class _CameraScreenState extends State<CameraScreen> {
   late CameraController _controller;
   bool _isInit = false;
   bool _isProcessing = false;
+  bool _showGuideline = true;
   String? _previewImagePath;
 
   @override
@@ -83,6 +84,11 @@ class _CameraScreenState extends State<CameraScreen> {
     if (isLandscape && ratio < 1) return 1 / ratio;
     if (!isLandscape && ratio > 1) return 1 / ratio;
     return ratio;
+  }
+
+  String get _guidelineUrl {
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    return "https://raw.githubusercontent.com/KAnggara75/everyday/main/timelapse/last.jpg?v=$timestamp";
   }
 
   Future<void> _takePicture() async {
@@ -239,6 +245,24 @@ class _CameraScreenState extends State<CameraScreen> {
                   ),
                 ),
 
+                // Guideline Overlay
+                if (_showGuideline)
+                  Center(
+                    child: AspectRatio(
+                      aspectRatio: 3 / 2,
+                      child: Opacity(
+                        opacity: 0.4,
+                        child: Image.network(
+                          _guidelineUrl,
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, error, stackTrace) {
+                            return const SizedBox();
+                          },
+                        ),
+                      ),
+                    ),
+                  ),
+
                 if (_previewImagePath != null)
                   Center(
                     child: AspectRatio(
@@ -266,8 +290,22 @@ class _CameraScreenState extends State<CameraScreen> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
-                // Spacer top
-                const SizedBox(height: 48),
+                // Spacer top & Guideline toggle
+                Padding(
+                  padding: const EdgeInsets.only(top: 24.0),
+                  child: IconButton(
+                    onPressed: () {
+                      setState(() {
+                        _showGuideline = !_showGuideline;
+                      });
+                    },
+                    icon: Icon(
+                      _showGuideline ? Icons.visibility : Icons.visibility_off,
+                      color: Colors.white,
+                      size: 28,
+                    ),
+                  ),
+                ),
 
                 // Tombol Capture
                 FloatingActionButton(


### PR DESCRIPTION
Implements the camera guideline overlay feature as described in issue #4. This includes fetching the latest image from GitHub with cache-busting and displaying it as a transparent overlay on the camera preview.